### PR TITLE
Add config generator

### DIFF
--- a/config-generator/config-generator-lib/pom.xml
+++ b/config-generator/config-generator-lib/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>quilt</groupId>
+        <artifactId>config-generator-pom</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>quilt</groupId>
+    <artifactId>config-generator-lib</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Config Generator Library</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.openshift</groupId>
+            <artifactId>openshift-restclient-java</artifactId>
+            <version>4.0.3.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.0.52-beta</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/generator/BrokerGenerator.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/generator/BrokerGenerator.java
@@ -1,0 +1,73 @@
+package quilt.config.generator;
+
+import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.internal.restclient.model.Port;
+import com.openshift.internal.restclient.model.ReplicationController;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IReplicationController;
+import quilt.config.model.Broker;
+import org.jboss.dmr.ModelNode;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author lulf
+ */
+public class BrokerGenerator {
+    private final ResourceFactory factory = new ResourceFactory(null);
+
+    public IReplicationController generate(Broker broker) {
+        ReplicationController controller = factory.create("v1", ResourceKind.REPLICATION_CONTROLLER);
+
+        controller.setName("broker-controller");
+        controller.setReplicas(1);
+        controller.addLabel("role", "broker");
+        controller.addLabel("address", broker.getAddress());
+        controller.addTemplateLabel("role", "broker");
+        controller.setReplicaSelector(Collections.singletonMap("role", "broker"));
+
+        generateBroker(controller);
+        generateConfigurationDaemon(controller, broker);
+        generateDispatchRouter(controller);
+
+        return controller;
+    }
+
+    private void generateBroker(ReplicationController controller) {
+        Port amqpPort = new Port(new ModelNode());
+        amqpPort.setContainerPort(5672);
+
+        controller.addContainer(
+                "broker",
+                new DockerImageURI("gordons/qpidd:v4"),
+                Collections.singleton(amqpPort),
+                Collections.emptyMap(),
+                Collections.emptyList());
+    }
+
+    private void generateConfigurationDaemon(ReplicationController controller, Broker broker) {
+        Map<String, String> env = new LinkedHashMap<>();
+        env.put("QUEUE_NAME", broker.getAddress());
+        controller.addContainer(
+                "configured",
+                new DockerImageURI("gordons/configured:v9"),
+                Collections.emptySet(),
+                env,
+                Collections.emptyList());
+    }
+
+    private void generateDispatchRouter(ReplicationController controller) {
+        Port interRouterPort = new Port(new ModelNode());
+        interRouterPort.setContainerPort(55672);
+
+        controller.addContainer(
+                "router",
+                new DockerImageURI("gordons/qdrouterd:v4"),
+                Collections.singleton(interRouterPort),
+                Collections.emptyMap(),
+                Collections.emptyList());
+    }
+}

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/generator/BrokerGenerator.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/generator/BrokerGenerator.java
@@ -29,39 +29,29 @@ public class BrokerGenerator {
         controller.addTemplateLabel("role", "broker");
         controller.setReplicaSelector(Collections.singletonMap("role", "broker"));
 
-        generateBroker(controller);
-        generateConfigurationDaemon(controller, broker);
+        generateBroker(controller, broker);
         generateDispatchRouter(controller);
 
         return controller;
     }
 
-    private void generateBroker(ReplicationController controller) {
+    private void generateBroker(ReplicationController controller, Broker broker) {
         Port amqpPort = new Port(new ModelNode());
-        amqpPort.setContainerPort(5672);
+        amqpPort.setContainerPort(5673);
+        Map<String, String> env = new LinkedHashMap<>();
+        env.put("QUEUE_NAME", broker.getAddress());
 
         controller.addContainer(
                 "broker",
                 new DockerImageURI("gordons/qpidd:v4"),
                 Collections.singleton(amqpPort),
-                Collections.emptyMap(),
-                Collections.emptyList());
-    }
-
-    private void generateConfigurationDaemon(ReplicationController controller, Broker broker) {
-        Map<String, String> env = new LinkedHashMap<>();
-        env.put("QUEUE_NAME", broker.getAddress());
-        controller.addContainer(
-                "configured",
-                new DockerImageURI("gordons/configured:v9"),
-                Collections.emptySet(),
                 env,
                 Collections.emptyList());
     }
 
     private void generateDispatchRouter(ReplicationController controller) {
         Port interRouterPort = new Port(new ModelNode());
-        interRouterPort.setContainerPort(55672);
+        interRouterPort.setContainerPort(5672);
 
         controller.addContainer(
                 "router",

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/generator/ConfigGenerator.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/generator/ConfigGenerator.java
@@ -1,0 +1,24 @@
+package quilt.config.generator;
+
+import com.openshift.restclient.model.IResource;
+import quilt.config.model.Broker;
+import quilt.config.model.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author lulf
+ */
+public class ConfigGenerator {
+
+    private final BrokerGenerator brokerGenerator = new BrokerGenerator();
+
+    public List<IResource> generate(Config config) {
+        List<IResource> resources = new ArrayList<>();
+        for (Broker broker : config.brokers()) {
+            resources.add(brokerGenerator.generate(broker));
+        }
+        return resources;
+    }
+}

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/model/Broker.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/model/Broker.java
@@ -1,0 +1,28 @@
+package quilt.config.model;
+
+/**
+ * @author lulf
+ */
+public final class Broker {
+    private final String address;
+    private final boolean storeAndForward;
+    private final boolean multicast;
+
+    public Broker(String address, boolean storeAndForward, boolean multicast) {
+        this.address = address;
+        this.storeAndForward = storeAndForward;
+        this.multicast = multicast;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public boolean storeAndForward() {
+        return storeAndForward;
+    }
+
+    public boolean multicast() {
+        return multicast;
+    }
+}

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/model/Config.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/model/Config.java
@@ -1,0 +1,19 @@
+package quilt.config.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author lulf
+ */
+public final class Config {
+    private final List<Broker> brokerList;
+
+    public Config(List<Broker> brokerList) {
+        this.brokerList = Collections.unmodifiableList(brokerList);
+    }
+
+    public List<Broker> brokers() {
+        return brokerList;
+    }
+}

--- a/config-generator/config-generator-lib/src/main/java/quilt/config/model/parser/ConfigParser.java
+++ b/config-generator/config-generator-lib/src/main/java/quilt/config/model/parser/ConfigParser.java
@@ -1,0 +1,37 @@
+package quilt.config.model.parser;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import quilt.config.model.Broker;
+import quilt.config.model.Config;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author lulf
+ */
+public class ConfigParser {
+    private final ObjectMapper mapper = new ObjectMapper();
+    public Config parse(Reader config) throws IOException {
+        JsonNode root = mapper.readTree(config);
+
+        Iterator<Map.Entry<String, JsonNode>> it = root.fields();
+
+        List<Broker> brokerList = new ArrayList<>();
+        while (it.hasNext()) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            Broker broker = new Broker(
+                    entry.getKey(),
+                    entry.getValue().get("store-and-forward").asBoolean(),
+                    entry.getValue().get("multicast").asBoolean());
+            brokerList.add(broker);
+        }
+
+        return new Config(brokerList);
+    }
+}

--- a/config-generator/config-generator-lib/src/test/java/quilt/config/generator/BrokerGeneratorTest.java
+++ b/config-generator/config-generator-lib/src/test/java/quilt/config/generator/BrokerGeneratorTest.java
@@ -1,0 +1,34 @@
+package quilt.config.generator;
+
+import com.openshift.restclient.model.IContainer;
+import com.openshift.restclient.model.IReplicationController;
+import org.junit.Test;
+import quilt.config.model.Broker;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author lulf
+ */
+public class BrokerGeneratorTest {
+    @Test
+    public void testGenerator() {
+        BrokerGenerator generator = new BrokerGenerator();
+        IReplicationController controller = generator.generate(new Broker("testaddr", true, false));
+
+        assertThat(controller.getLabels().get("role"), is("broker"));
+        assertThat(controller.getContainers().size(), is(3));
+
+        IContainer broker = controller.getContainer("broker");
+        assertThat(broker.getPorts().size(), is(1));
+        assertThat(broker.getPorts().iterator().next().getContainerPort(), is(5672));
+
+        IContainer configured = controller.getContainer("configured");
+        assertThat(configured.getEnvVars().get("QUEUE_NAME"), is("testaddr"));
+
+        IContainer router = controller.getContainer("router");
+        assertThat(router.getPorts().size(), is(1));
+        assertThat(router.getPorts().iterator().next().getContainerPort(), is(55672));
+    }
+}

--- a/config-generator/config-generator-tool/pom.xml
+++ b/config-generator/config-generator-tool/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>quilt</groupId>
+        <artifactId>config-generator-pom</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>quilt</groupId>
+    <artifactId>config-generator-tool</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Config Generator Standalone Tool</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>quilt</groupId>
+            <artifactId>config-generator-lib</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>quilt.config.generator.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+u

--- a/config-generator/config-generator-tool/src/main/java/quilt/config/generator/FileGenerator.java
+++ b/config-generator/config-generator-tool/src/main/java/quilt/config/generator/FileGenerator.java
@@ -1,0 +1,55 @@
+package quilt.config.generator;
+
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IReplicationController;
+import com.openshift.restclient.model.IResource;
+import quilt.config.model.Config;
+import quilt.config.model.parser.ConfigParser;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author lulf
+ */
+public class FileGenerator {
+
+    private final ConfigParser parser = new ConfigParser();
+    private final ConfigGenerator generator = new ConfigGenerator();
+
+    private static final String BROKER_CLUSTER_PATTERN = "broker_cluster_%s.json";
+
+    public void generate(String inputFilePath, String outputDirPath) throws IOException {
+        File inputFile = new File(inputFilePath);
+        File outputDir = new File(outputDirPath);
+
+        try (FileReader reader = new FileReader(inputFile)) {
+            Config config = parser.parse(reader);
+            generateConfig(config, outputDir);
+        }
+    }
+
+    private void generateConfig(Config config, File outputDir) throws IOException {
+        List<IResource> resources = generator.generate(config);
+        for (IResource resource : resources) {
+            if (ResourceKind.REPLICATION_CONTROLLER.equals(resource.getKind())) {
+                generateBroker((IReplicationController)resource, outputDir);
+            }
+        }
+    }
+
+    private void generateBroker(IReplicationController resource, File outputDir) throws IOException {
+        String address = resource.getLabels().get("address");
+        File brokerFile = new File(outputDir, String.format(BROKER_CLUSTER_PATTERN, address));
+        writeBrokerConfig(resource, brokerFile);
+    }
+
+    private void writeBrokerConfig(IReplicationController replicationController, File brokerFile) throws IOException {
+        try (FileWriter writer = new FileWriter(brokerFile)) {
+            writer.write(replicationController.toJson(false));
+        }
+    }
+}

--- a/config-generator/config-generator-tool/src/main/java/quilt/config/generator/Main.java
+++ b/config-generator/config-generator-tool/src/main/java/quilt/config/generator/Main.java
@@ -1,0 +1,48 @@
+package quilt.config.generator;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.io.IOException;
+
+/**
+ * @author lulf
+ */
+public class Main {
+    public static void main(String [] args) {
+        CommandLineParser parser = new DefaultParser();
+
+        Options options = new Options();
+        options.addOption(createRequiredOption("i", "inputFile", "Input configuration file"));
+        options.addOption(createRequiredOption("o", "outputDir", "Output directory"));
+
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            new FileGenerator().generate(cmd.getOptionValue("i"), cmd.getOptionValue("o"));
+
+        } catch (ParseException e) {
+            System.out.println(String.format("Unable to parse arguments: %s", e.getMessage()));
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("config-generator", options);
+            System.exit(1);
+
+        } catch (IOException e) {
+            System.out.println(String.format("Error generating config: %s", e.getMessage()));
+            System.exit(1);
+        }
+    }
+
+    private static Option createRequiredOption(String name, String longName, String description) {
+        return Option.builder(name)
+                .longOpt(longName)
+                .hasArg()
+                .desc(description)
+                .required()
+                .build();
+    }
+}

--- a/config-generator/config-generator-tool/src/main/sh/config-generator.sh
+++ b/config-generator/config-generator-tool/src/main/sh/config-generator.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+JARFILE=/usr/lib/jars/config-generator-tool.jar
+exec /usr/bin/java -jar $JARFILE $@

--- a/config-generator/config-generator-tool/src/test/java/quilt/config/generator/FileGeneratorTest.java
+++ b/config-generator/config-generator-tool/src/test/java/quilt/config/generator/FileGeneratorTest.java
@@ -1,0 +1,58 @@
+package quilt.config.generator;
+
+import com.openshift.internal.util.Assert;
+import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import quilt.config.generator.ConfigGenerator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author lulf
+ */
+public class FileGeneratorTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static FileGenerator generator;
+
+    @BeforeClass
+    public static void setUpOnce() {
+        generator = new FileGenerator();
+    }
+
+    @Test
+    public void testBrokerGenerator() throws IOException {
+        File outputDir = folder.newFolder();
+        generator.generate("src/test/resources/example-config.json", outputDir.getAbsolutePath());
+
+        File[] outputFiles = outputDir.listFiles();
+        assertThat(outputFiles.length, CoreMatchers.is(2));
+
+        File addr1 = findFile(outputFiles, "broker_cluster_addr1.json").get();
+        assertNotNull(addr1);
+
+        File addr2 = findFile(outputFiles, "broker_cluster_addr2.json").get();
+        assertNotNull(addr1);
+    }
+
+    private Optional<File> findFile(File[] outputFiles, String fileName) {
+        for (File file : outputFiles) {
+            if (fileName.equals(file.getName())) {
+                return Optional.of(file);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/config-generator/config-generator-tool/src/test/resources/example-config.json
+++ b/config-generator/config-generator-tool/src/test/resources/example-config.json
@@ -1,0 +1,10 @@
+{
+  "addr1": {
+    "store-and-forward": true,
+    "multicast": false
+  },
+  "addr2": {
+    "store-and-forward": false,
+    "multicast": true
+  }
+}

--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>quilt</groupId>
+    <artifactId>config-generator-pom</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Config Generator Parent</name>
+
+    <properties>
+        <jackson.version>2.7.4</jackson.version>
+        <junit.version>4.12</junit.version>
+    </properties>
+
+    <modules>
+        <module>config-generator-lib</module>
+        <module>config-generator-tool</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
- Consists of a library that parses a JSON config file, and uses openshift-restclient-java to build
  the resulting config. Only supports configuring the kubernetes replicationcontroller for brokers
  for now.
- A standalone tool using the above library to output config to files.
